### PR TITLE
Fix Access-Control-Allow-Origin & various other fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ return [
     'default_profile' => [
 
         'allow_origins' => [
-            '*'
+            '*',
         ],
 
         'allow_methods' => [
@@ -82,7 +82,8 @@ return [
             'GET',
             'OPTIONS',
             'PUT',
-            'DELETE'
+            'PATCH',
+            'DELETE',
         ],
 
         'allow_headers' => [
@@ -191,7 +192,7 @@ We publish all received postcards [on our company website](https://spatie.be/en/
 
 Spatie is a webdesign agency based in Antwerp, Belgium. You'll find an overview of all our open source projects [on our website](https://spatie.be/opensource).
 
-Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie). 
+Does your business depend on our contributions? Reach out and support us on [Patreon](https://www.patreon.com/spatie).
 All pledges will be dedicated to allocating workforce on maintenance and new awesome stuff.
 
 ## License

--- a/config/cors.php
+++ b/config/cors.php
@@ -26,6 +26,7 @@ return [
             'GET',
             'OPTIONS',
             'PUT',
+            'PATCH',
             'DELETE',
         ],
 

--- a/src/Cors.php
+++ b/src/Cors.php
@@ -64,7 +64,7 @@ class Cors
             return $this->forbiddenResponse();
         }
 
-        return $this->corsProfile->addPreflightheaders(response('Preflight OK', 200));
+        return $this->corsProfile->addPreflightHeaders(response('Preflight OK', 200));
     }
 
     protected function forbiddenResponse()

--- a/src/CorsProfile/CorsProfile.php
+++ b/src/CorsProfile/CorsProfile.php
@@ -2,8 +2,6 @@
 
 namespace Spatie\Cors\CorsProfile;
 
-use Symfony\Component\HttpFoundation\Response;
-
 interface CorsProfile
 {
     public function setRequest($request);

--- a/src/CorsProfile/CorsProfile.php
+++ b/src/CorsProfile/CorsProfile.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\Cors\CorsProfile;
 
+use Symfony\Component\HttpFoundation\Response;
+
 interface CorsProfile
 {
     public function setRequest($request);
@@ -11,6 +13,10 @@ interface CorsProfile
     public function allowMethods(): array;
 
     public function allowHeaders(): array;
+
+    public function addCorsHeaders($response);
+
+    public function addPreflightHeaders($response);
 
     public function maxAge(): int;
 

--- a/src/CorsProfile/DefaultProfile.php
+++ b/src/CorsProfile/DefaultProfile.php
@@ -35,7 +35,7 @@ class DefaultProfile implements CorsProfile
     public function addCorsHeaders($response)
     {
         return $response
-            ->header('Access-Control-Allow-Origin', $this->toString($this->allowOrigins()));
+            ->header('Access-Control-Allow-Origin', $this->allowedOriginsToString());
     }
 
     public function addPreflightHeaders($response)
@@ -43,7 +43,7 @@ class DefaultProfile implements CorsProfile
         return $response
             ->header('Access-Control-Allow-Methods', $this->toString($this->allowMethods()))
             ->header('Access-Control-Allow-Headers', $this->toString($this->allowHeaders()))
-            ->header('Access-Control-Allow-Origin', $this->toString($this->allowOrigins()))
+            ->header('Access-Control-Allow-Origin', $this->allowedOriginsToString())
             ->header('Access-Control-Max-Age', $this->maxAge());
     }
 
@@ -63,5 +63,18 @@ class DefaultProfile implements CorsProfile
     protected function toString(array $array): string
     {
         return implode(', ', $array);
+    }
+
+    protected function allowedOriginsToString(): string
+    {
+        if (! $this->isAllowed()) {
+            return '';
+        }
+
+        if (in_array('*', $this->allowOrigins())) {
+            return '*';
+        }
+
+        return $this->request->header('Origin');
     }
 }

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -5,12 +5,37 @@ namespace Spatie\Cors\Tests;
 class CorsTest extends TestCase
 {
     /** @test */
-    public function it_add_the_cors_headers_on_a_valid_requests()
+    public function it_adds_the_cors_headers_on_a_valid_requests()
     {
         $this
             ->sendRequest('POST', 'https://spatie.be')
             ->assertSuccessful()
             ->assertHeader('Access-Control-Allow-Origin', '*')
+            ->assertSee('real content');
+    }
+
+    /** @test */
+    public function it_adds_the_wildcard_in_the_cors_headers_on_a_valid_request_if_no_allow_origins_are_set()
+    {
+        $this
+            ->sendRequest('POST', 'https://spatie.be')
+            ->assertSuccessful()
+            ->assertHeader('Access-Control-Allow-Origin', '*')
+            ->assertSee('real content');
+    }
+
+    /** @test */
+    public function it_adds_the_origin_domain_in_the_cors_headers_on_a_valid_request()
+    {
+        config()->set('cors.default_profile.allow_origins', [
+            'https://spatie.be',
+            'https://laravel.com',
+        ]);
+
+        $this
+            ->sendRequest('POST', 'https://spatie.be')
+            ->assertSuccessful()
+            ->assertHeader('Access-Control-Allow-Origin', 'https://spatie.be')
             ->assertSee('real content');
     }
 

--- a/tests/PreflightTest.php
+++ b/tests/PreflightTest.php
@@ -11,7 +11,7 @@ class PreflightTest extends TestCase
             ->sendPreflightRequest('DELETE', 'https://spatie.be')
             ->assertSuccessful()
             ->assertSee('Preflight OK')
-            ->assertHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS, PUT, DELETE')
+            ->assertHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS, PUT, PATCH, DELETE')
             ->assertHeader('Access-Control-Allow-Headers', 'Content-Type, X-Auth-Token, Origin, Authorization')
             ->assertHeader('Access-Control-Allow-Origin', '*')
             ->assertHeader('Access-Control-Max-Age', 60 * 60 * 24);


### PR DESCRIPTION
- add `PATCH` to default allowed methods
- add `addPreflightHeaders` and `addCorsHeaders` to interface (they're required by `Cors`)
- add `allowedOriginsToString`: returns the allowed origin domain or wildcard `*` for `Fix Access-Control-Allow-Origin` header
- add 2 tests to confirm `Fix Access-Control-Allow-Origin` is correct