### PR TITLE
fix typo

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -3,7 +3,7 @@
 return [
 
     /*
-     * A cors profile determines which orgins, methods, headers are allowed for
+     * A cors profile determines which origins, methods, headers are allowed for
      * a given requests. The `DefaultProfile` reads its configuration from this
      * config file.
      *


### PR DESCRIPTION
just changed “orgins” to “origins”