### PR TITLE
Add an option to manage Access-Control-Expose-Headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,15 @@ return [
             'Origin',
             'Authorization',
         ],
+
+        'expose_headers' => [
+            'Cache-Control',
+            'Content-Language',
+            'Content-Type',
+            'Expires',
+            'Last-Modified',
+            'Pragma',
+        ],
         
         'forbidden_response' => [
             'message' => 'Forbidden (cors).',

--- a/config/cors.php
+++ b/config/cors.php
@@ -37,6 +37,15 @@ return [
             'Authorization',
         ],
 
+        'expose_headers' => [
+            'Cache-Control',
+            'Content-Language',
+            'Content-Type',
+            'Expires',
+            'Last-Modified',
+            'Pragma',
+        ],
+
         'forbidden_response' => [
             'message' => 'Forbidden (cors).',
             'status' => 403,

--- a/src/CorsProfile/CorsProfile.php
+++ b/src/CorsProfile/CorsProfile.php
@@ -12,6 +12,8 @@ interface CorsProfile
 
     public function allowHeaders(): array;
 
+    public function exposeHeaders(): array;
+
     public function addCorsHeaders($response);
 
     public function addPreflightHeaders($response);

--- a/src/CorsProfile/DefaultProfile.php
+++ b/src/CorsProfile/DefaultProfile.php
@@ -27,6 +27,11 @@ class DefaultProfile implements CorsProfile
         return config('cors.default_profile.allow_headers');
     }
 
+    public function exposeHeaders(): array
+    {
+        return config('cors.default_profile.expose_headers');
+    }
+
     public function maxAge(): int
     {
         return config('cors.default_profile.max_age');
@@ -35,7 +40,8 @@ class DefaultProfile implements CorsProfile
     public function addCorsHeaders($response)
     {
         return $response
-            ->header('Access-Control-Allow-Origin', $this->allowedOriginsToString());
+            ->header('Access-Control-Allow-Origin', $this->allowedOriginsToString())
+            ->header('Access-Control-Expose-Headers', $this->toString($this->exposeHeaders()));
     }
 
     public function addPreflightHeaders($response)

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -40,6 +40,22 @@ class CorsTest extends TestCase
     }
 
     /** @test */
+    public function it_adds_the_allowed_expose_headers_in_the_cors_headers_on_a_valid_request()
+    {
+        config()->set('cors.default_profile.expose_headers', [
+            'Authorization',
+            'X-Foo-Header',
+        ]);
+
+        $this
+            ->sendRequest('POST', 'https://spatie.be')
+            ->assertSuccessful()
+            ->assertHeader('Access-Control-Expose-Headers', 'Authorization, X-Foo-Header')
+            ->assertHeader('Access-Control-Allow-Origin', '*')
+            ->assertSee('real content');
+    }
+
+    /** @test */
     public function it_will_send_a_403_for_invalid_requests()
     {
         config()->set('cors.default_profile.allow_origins', ['https://spatie.be']);


### PR DESCRIPTION
This PR adds an option to manage the Access-Control-Expose-Headers header value: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers

I use spatie/laravel-cors in one of my applications that is sending a token in an `Authorization` response header. I was surprised that i cannot access the header value from my js code.
When a response comes from a CORS request, it looks like the browser can only access the following default headers (access it via a js client for example):

- Cache-Control
- Content-Language
- Content-Type
- Expires
- Last-Modified
- Pragma

Any other header cannot be accessed by the browser without being explicitly withelisted in the Access-Control-Expose-Headers.

So the goal of this PR is to be able to set the Access-Control-Expose-Headers value from the application.

The default header values are included in the configuration file.