### PR TITLE
Streamed response support

### DIFF
--- a/src/CorsProfile/DefaultProfile.php
+++ b/src/CorsProfile/DefaultProfile.php
@@ -39,18 +39,20 @@ class DefaultProfile implements CorsProfile
 
     public function addCorsHeaders($response)
     {
-        return $response
-            ->header('Access-Control-Allow-Origin', $this->allowedOriginsToString())
-            ->header('Access-Control-Expose-Headers', $this->toString($this->exposeHeaders()));
+        $response->headers->set('Access-Control-Allow-Origin', $this->allowedOriginsToString());
+        $response->headers->set('Access-Control-Expose-Headers', $this->toString($this->exposeHeaders()));
+
+        return $response;
     }
 
     public function addPreflightHeaders($response)
     {
-        return $response
-            ->header('Access-Control-Allow-Methods', $this->toString($this->allowMethods()))
-            ->header('Access-Control-Allow-Headers', $this->toString($this->allowHeaders()))
-            ->header('Access-Control-Allow-Origin', $this->allowedOriginsToString())
-            ->header('Access-Control-Max-Age', $this->maxAge());
+        $response->headers->set('Access-Control-Allow-Methods', $this->toString($this->allowMethods()));
+        $response->headers->set('Access-Control-Allow-Headers', $this->toString($this->allowHeaders()));
+        $response->headers->set('Access-Control-Allow-Origin', $this->allowedOriginsToString());
+        $response->headers->set('Access-Control-Max-Age', $this->maxAge());
+
+        return $response;
     }
 
     public function isAllowed(): bool

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -95,7 +95,16 @@ class CorsTest extends TestCase
             ->assertSee('real content');
     }
 
-    public function sendRequest(string $method, string $origin)
+    /** @test */
+    public function it_adds_the_cors_headers_on_a_valid_stream_request()
+    {
+        $this
+            ->sendRequest('POST', 'https://spatie.be', 'test-cors-stream')
+            ->assertSuccessful()
+            ->assertHeader('Access-Control-Allow-Origin', '*');
+    }
+
+    public function sendRequest(string $method, string $origin, string $uri = 'test-cors')
     {
         $headers = [
             'Origin' => $origin,
@@ -103,6 +112,6 @@ class CorsTest extends TestCase
 
         $server = $this->transformHeadersToServerVars($headers);
 
-        return $this->call($method, 'test-cors', [], [], [], $server);
+        return $this->call($method, $uri, [], [], [], $server);
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ use Spatie\Cors\Cors;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\Facades\Route;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class TestCase extends Orchestra
 {
@@ -20,6 +21,10 @@ class TestCase extends Orchestra
     {
         Route::post('test-cors', function () {
             return 'real content';
+        });
+
+        Route::post('test-cors-stream', function () {
+            return new StreamedResponse();
         });
     }
 


### PR DESCRIPTION
Currently this package won't work for responses that don't implement the `header()` method for setting headers on a response. This is a problem I recently encountered when trying to add CORS support to a `POST` request that streamed a file.

For example:

```php
Route::post('/', function () {
    return Storage::disk('public')->download('file.pdf');
});
```

In order to fix the issue I have updated the default profile to access the `ResponseHeaderBag` on the response directly and use that to set the header values. This should work for all responses that inherit from `Symfony\Component\HttpFoundation\Response` which includes all Laravel responses.

Before:
```php
$response->header('Access-Control-Allow-Origin');
```

After:
```php
$response->headers->set('Access-Control-Allow-Origin');
```