### PR TITLE
Add default Laravel headers to allow_headers

### DIFF
--- a/config/cors.php
+++ b/config/cors.php
@@ -33,6 +33,8 @@ return [
         'allow_headers' => [
             'Content-Type',
             'X-Auth-Token',
+            'X-CSRF-TOKEN',
+            'X-Requested-With',
             'Origin',
             'Authorization',
         ],


### PR DESCRIPTION
Close #20

I think many users have to add these 2 headers manually, just after installing the package:
- X-CSRF-TOKEN
- X-Requested-With

Axios, the default http client use these headers by default on every fresh Laravel installation.
It is better to include them directly, isn't it?