### PR TITLE
return default value for allow credentials when not available in config

### DIFF
--- a/src/CorsProfile/DefaultProfile.php
+++ b/src/CorsProfile/DefaultProfile.php
@@ -14,7 +14,7 @@ class DefaultProfile implements CorsProfile
 
     public function allowCredentials(): bool
     {
-        return config('cors.default_profile.allow_credentials');
+        return config('cors.default_profile.allow_credentials') ?? false;
     }
 
     public function allowOrigins(): array

--- a/tests/DefaultProfileTest.php
+++ b/tests/DefaultProfileTest.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\Cors\Tests;
+
+use Spatie\Cors\CorsProfile\DefaultProfile;
+
+class DefaultProfileTest extends TestCase
+{
+    /** @test */
+    public function it_returns_false_when_allow_credentials_is_not_set_in_config()
+    {
+        config()->set('cors.default_profile.allow_credentials', null);
+
+        $defaultProfile = new DefaultProfile();
+
+        $this->assertFalse($defaultProfile->allowCredentials());
+    }
+}


### PR DESCRIPTION
@freekmurze As discussed :)

https://github.com/spatie/laravel-cors/pull/31#issuecomment-417359069