### PR TITLE
Added logic for allow_credentials missing from config

### DIFF
--- a/src/CorsProfile/DefaultProfile.php
+++ b/src/CorsProfile/DefaultProfile.php
@@ -14,7 +14,7 @@ class DefaultProfile implements CorsProfile
 
     public function allowCredentials(): bool
     {
-        return config('cors.default_profile.allow_credentials');
+        return config('cors.default_profile.allow_credentials') ? true : false;
     }
 
     public function allowOrigins(): array

--- a/tests/CorsTest.php
+++ b/tests/CorsTest.php
@@ -54,6 +54,22 @@ class CorsTest extends TestCase
     }
 
     /** @test */
+    public function it_does_not_add_the_credentials_cors_headers_on_a_valid_request_if_allow_credentials_is_set_to_null()
+    {
+        config()->set('cors.default_profile.allow_credentials', null);
+
+        $response = $this
+            ->sendRequest('POST', 'https://spatie.be')
+            ->assertSuccessful()
+            ->assertHeader('Access-Control-Allow-Origin', '*')
+            ->assertSee('real content');
+
+        $headerName = 'Access-Control-Allow-Credentials';
+
+        $this->assertFalse($response->headers->has($headerName), "Unexpected header [{$headerName}] is present on response.");
+    }
+
+    /** @test */
     public function it_adds_the_origin_domain_in_the_cors_headers_on_a_valid_request()
     {
         config()->set('cors.default_profile.allow_origins', [

--- a/tests/PreflightTest.php
+++ b/tests/PreflightTest.php
@@ -53,6 +53,20 @@ class PreflightTest extends TestCase
     }
 
     /** @test */
+    public function it_responds_with_correct_header_for_a_preflight_request_when_allow_credentials_is_set_to_null()
+    {
+        config()->set('cors.default_profile.allow_credentials', null);
+
+        $response = $this
+            ->sendPreflightRequest('DELETE', 'https://spatie.be')
+            ->assertHeader('Access-Control-Allow-Origin', '*');
+
+        $headerName = 'Access-Control-Allow-Credentials';
+
+        $this->assertFalse($response->headers->has($headerName), "Unexpected header [{$headerName}] is present on response.");
+    }
+
+    /** @test */
     public function it_responds_with_a_200_for_a_preflight_request_coming_from_an_allowed_origin()
     {
         config()->set('cors.default_profile.allow_origins', ['https://spatie.be']);


### PR DESCRIPTION
This is to add backward compatibility with configs without the allow_credentials value.