### PR TITLE
Add protocol to mozilla CORS documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![StyleCI](https://styleci.io/repos/113957368/shield?branch=master)](https://styleci.io/repos/113957368)
 [![Total Downloads](https://img.shields.io/packagist/dt/spatie/laravel-cors.svg?style=flat-square)](https://packagist.org/packages/spatie/laravel-cors)
 
-This package will add CORS headers to the responses of your Laravel or Lumen app. For more infomation about CORS, see the [Mozilla CORS documentation](developer.mozilla.org/en-US/docs/Web/HTTP/CORS).
+This package will add CORS headers to the responses of your Laravel or Lumen app. For more infomation about CORS, see the [Mozilla CORS documentation](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS).
 
 This package supports preflight requests and is easily configurable to fit your needs.
 


### PR DESCRIPTION
This is a super minor thing, but with the latest update to the README file, no `http` part was added to the url, so Github tries to open this link instead `https://github.com/spatie/laravel-cors/blob/master/developer.mozilla.org/en-US/docs/Web/HTTP/CORS`.

That's all.

Thank y'all for your awesome packages!