### PR TITLE
Fix: return empty response for 204 preflight requests

### DIFF
--- a/src/Cors.php
+++ b/src/Cors.php
@@ -63,7 +63,7 @@ class Cors
             return $this->forbiddenResponse();
         }
 
-        return $this->corsProfile->addPreflightHeaders(response('Preflight OK', 204));
+        return $this->corsProfile->addPreflightHeaders(response(null, 204));
     }
 
     protected function forbiddenResponse()

--- a/tests/PreflightTest.php
+++ b/tests/PreflightTest.php
@@ -5,16 +5,17 @@ namespace Spatie\Cors\Tests;
 class PreflightTest extends TestCase
 {
     /** @test */
-    public function it_responds_with_a_200_for_a_valid_preflight_request()
+    public function it_responds_with_a_204_for_a_valid_preflight_request()
     {
         $response = $this
             ->sendPreflightRequest('DELETE', 'https://spatie.be')
-            ->assertSuccessful()
-            ->assertSee('Preflight OK')
+            ->assertStatus(204)
             ->assertHeader('Access-Control-Allow-Methods', 'POST, GET, OPTIONS, PUT, PATCH, DELETE')
             ->assertHeader('Access-Control-Allow-Headers', 'Content-Type, X-Auth-Token, Origin, Authorization')
             ->assertHeader('Access-Control-Allow-Origin', '*')
             ->assertHeader('Access-Control-Max-Age', 60 * 60 * 24);
+
+        $this->assertEmpty($response->content());
     }
 
     /** @test */
@@ -53,7 +54,7 @@ class PreflightTest extends TestCase
     }
 
     /** @test */
-    public function it_responds_with_a_200_for_a_preflight_request_coming_from_an_allowed_origin()
+    public function it_responds_with_a_204_for_a_preflight_request_coming_from_an_allowed_origin()
     {
         config()->set('cors.default_profile.allow_origins', ['https://spatie.be']);
 


### PR DESCRIPTION
As mentioned in https://github.com/spatie/laravel-cors/issues/60, it appears that returning a `204 No Content` response with content indeed causes odd behaviour in some clients. This PR fixes that by removing the 'Preflight OK' text, so it follows the [specs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/204). 

Related info:
https://github.com/httpwg/http-core/issues/26
https://github.com/postmanlabs/postman-app-support/issues/2418